### PR TITLE
feat(config): externalize FakeStore base URL using @ConfigurationProperties

### DIFF
--- a/src/main/java/org/example/ecommercespring/configuration/FakeStoreProperties.java
+++ b/src/main/java/org/example/ecommercespring/configuration/FakeStoreProperties.java
@@ -1,0 +1,18 @@
+package org.example.ecommercespring.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "fake-store")
+public class FakeStoreProperties {
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
+++ b/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
@@ -9,11 +9,10 @@ import retrofit2.converter.gson.GsonConverterFactory;
 @Configuration
 public class RetrofitConfig {
 
-
     @Bean
-    public Retrofit retrofit() {
+    public Retrofit retrofit(FakeStoreProperties properties) {
         return new Retrofit.Builder()
-                .baseUrl("https://fakestoreapi.in/api/")
+                .baseUrl(properties.getBaseUrl())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
     }
@@ -22,5 +21,4 @@ public class RetrofitConfig {
     public FakeStoreCategoryApi fakeStoreCategoryApi(Retrofit retrofit) {
         return retrofit.create(FakeStoreCategoryApi.class);
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=EcommerceSpring
 
 server.port=${PORT}
+fake-store.base-url=${FAKESTOREBASEURL}


### PR DESCRIPTION
## Description

This PR refactors the configuration of the FakeStore API base URL by moving it out of the source code and into external configuration. It leverages Spring Boot’s `@ConfigurationProperties` to bind values from external sources, such as `.env` files or `application.properties`.

## Changes Made

- Added `FakeStoreProperties` class with `@ConfigurationProperties(prefix = "fake-store")` to handle API config.
- Modified `RetrofitConfig` to consume the `baseUrl` from `FakeStoreProperties` instead of hardcoding.
- Ensured environment variables can be loaded using the `dotenv-java` library.

## Why This Change?

- ✅ Cleaner and environment-agnostic configuration.
- ✅ Easier management across dev, staging, and production environments.
- ✅ Makes future configuration properties scalable and maintainable.
- ✅ Aligns with Spring Boot best practices.

## How to Use

### 1. Create a `.env` file in your project root directory:

```env
PORT=3001
FAKESTOREBASEURL=https://fakestoreapi.in/api/
