### PR TITLE
feat: integrate product list & single product API with clean DTO structure

### DIFF
--- a/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
+++ b/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
@@ -1,6 +1,7 @@
 package org.example.ecommercespring.configuration;
 
 import org.example.ecommercespring.gateway.api.FakeStoreCategoryApi;
+import org.example.ecommercespring.gateway.api.FakeStoreProductApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit2.Retrofit;
@@ -9,11 +10,10 @@ import retrofit2.converter.gson.GsonConverterFactory;
 @Configuration
 public class RetrofitConfig {
 
-
     @Bean
     public Retrofit retrofit() {
         return new Retrofit.Builder()
-                .baseUrl("https://fakestoreapi.in/api/")
+                .baseUrl("https://fakestoreapi.in/api/") // ideally use the config-based url
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
     }
@@ -23,4 +23,8 @@ public class RetrofitConfig {
         return retrofit.create(FakeStoreCategoryApi.class);
     }
 
+    @Bean
+    public FakeStoreProductApi fakeStoreProductApi(Retrofit retrofit) {
+        return retrofit.create(FakeStoreProductApi.class);
+    }
 }

--- a/src/main/java/org/example/ecommercespring/controllers/ProductController.java
+++ b/src/main/java/org/example/ecommercespring/controllers/ProductController.java
@@ -1,6 +1,7 @@
 package org.example.ecommercespring.controllers;
 
-import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.dto.ProductListDTO;
+import org.example.ecommercespring.dto.ProductSingleDTO;
 import org.example.ecommercespring.services.IProductService;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +19,12 @@ public class ProductController {
     }
 
     @GetMapping
-    public List<ProductDTO> getAllProducts() throws IOException {
+    public List<ProductListDTO> getAllProducts() throws IOException {
         return this.productService.getAllProducts();
+    }
+
+    @GetMapping("/{id}")
+    public ProductSingleDTO getProductById(@PathVariable int id) throws IOException {
+        return this.productService.getProductById(id);
     }
 }

--- a/src/main/java/org/example/ecommercespring/controllers/ProductController.java
+++ b/src/main/java/org/example/ecommercespring/controllers/ProductController.java
@@ -1,0 +1,24 @@
+package org.example.ecommercespring.controllers;
+
+import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.services.IProductService;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+    private final IProductService productService;
+
+    public ProductController(IProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping
+    public List<ProductDTO> getAllProducts() throws IOException {
+        return this.productService.getAllProducts();
+    }
+}

--- a/src/main/java/org/example/ecommercespring/dto/FakeStoreProductResponseDTO.java
+++ b/src/main/java/org/example/ecommercespring/dto/FakeStoreProductResponseDTO.java
@@ -1,0 +1,16 @@
+package org.example.ecommercespring.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FakeStoreProductResponseDTO {
+    private String status;
+    private String message;
+    private List<ProductDTO> products;
+}

--- a/src/main/java/org/example/ecommercespring/dto/FakeStoreSingleProductResponseDTO.java
+++ b/src/main/java/org/example/ecommercespring/dto/FakeStoreSingleProductResponseDTO.java
@@ -1,15 +1,14 @@
 package org.example.ecommercespring.dto;
 
 import lombok.*;
-import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class FakeStoreProductResponseDTO {
+public class FakeStoreSingleProductResponseDTO {
     private String status;
     private String message;
-    private List<ProductListDTO> products;
+    private ProductSingleDTO product;
 }

--- a/src/main/java/org/example/ecommercespring/dto/ProductDTO.java
+++ b/src/main/java/org/example/ecommercespring/dto/ProductDTO.java
@@ -1,0 +1,23 @@
+package org.example.ecommercespring.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProductDTO {
+    private int id;
+    private String title;
+    private String image;
+    private double price;
+    private String description;
+    private String brand;
+    private String model;
+    private String color;
+    private String category;
+    private boolean popular;
+    private boolean onSale;
+    private int discount;
+}

--- a/src/main/java/org/example/ecommercespring/dto/ProductListDTO.java
+++ b/src/main/java/org/example/ecommercespring/dto/ProductListDTO.java
@@ -1,0 +1,23 @@
+package org.example.ecommercespring.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProductListDTO {
+    private int id;
+    private String title;
+    private String image;
+    private double price;
+    private String description;
+    private String brand;
+    private String model;
+    private String color;
+    private String category;
+    private boolean popular;
+    private boolean onSale;
+    private int discount;
+}

--- a/src/main/java/org/example/ecommercespring/dto/ProductSingleDTO.java
+++ b/src/main/java/org/example/ecommercespring/dto/ProductSingleDTO.java
@@ -7,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class ProductDTO {
+public class ProductSingleDTO {
     private int id;
     private String title;
     private String image;
@@ -18,6 +18,5 @@ public class ProductDTO {
     private String color;
     private String category;
     private boolean popular;
-    private boolean onSale;
     private int discount;
 }

--- a/src/main/java/org/example/ecommercespring/gateway/FakeStoreProductGateway.java
+++ b/src/main/java/org/example/ecommercespring/gateway/FakeStoreProductGateway.java
@@ -1,0 +1,30 @@
+package org.example.ecommercespring.gateway;
+
+import org.example.ecommercespring.dto.FakeStoreProductResponseDTO;
+import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.gateway.api.FakeStoreProductApi;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class FakeStoreProductGateway implements IProductGateway {
+
+    private final FakeStoreProductApi fakeStoreProductApi;
+
+    public FakeStoreProductGateway(FakeStoreProductApi fakeStoreProductApi) {
+        this.fakeStoreProductApi = fakeStoreProductApi;
+    }
+
+    @Override
+    public List<ProductDTO> getAllProducts() throws IOException {
+        FakeStoreProductResponseDTO response = this.fakeStoreProductApi.getAllProducts().execute().body();
+
+        if (response == null || response.getProducts() == null) {
+            throw new IOException("Failed to fetch products from FakeStore API");
+        }
+
+        return response.getProducts();
+    }
+}

--- a/src/main/java/org/example/ecommercespring/gateway/FakeStoreProductGateway.java
+++ b/src/main/java/org/example/ecommercespring/gateway/FakeStoreProductGateway.java
@@ -1,7 +1,9 @@
 package org.example.ecommercespring.gateway;
 
 import org.example.ecommercespring.dto.FakeStoreProductResponseDTO;
-import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.dto.FakeStoreSingleProductResponseDTO;
+import org.example.ecommercespring.dto.ProductListDTO;
+import org.example.ecommercespring.dto.ProductSingleDTO;
 import org.example.ecommercespring.gateway.api.FakeStoreProductApi;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +20,7 @@ public class FakeStoreProductGateway implements IProductGateway {
     }
 
     @Override
-    public List<ProductDTO> getAllProducts() throws IOException {
+    public List<ProductListDTO> getAllProducts() throws IOException {
         FakeStoreProductResponseDTO response = this.fakeStoreProductApi.getAllProducts().execute().body();
 
         if (response == null || response.getProducts() == null) {
@@ -26,5 +28,14 @@ public class FakeStoreProductGateway implements IProductGateway {
         }
 
         return response.getProducts();
+    }
+
+    @Override
+    public ProductSingleDTO getProductById(int id) throws IOException {
+        FakeStoreSingleProductResponseDTO response = this.fakeStoreProductApi.getProductById(id).execute().body();
+        if (response == null || response.getProduct() == null) {
+            throw new IOException("Product not found for id: " + id);
+        }
+        return response.getProduct();
     }
 }

--- a/src/main/java/org/example/ecommercespring/gateway/IProductGateway.java
+++ b/src/main/java/org/example/ecommercespring/gateway/IProductGateway.java
@@ -1,10 +1,12 @@
 package org.example.ecommercespring.gateway;
 
-import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.dto.ProductListDTO;
+import org.example.ecommercespring.dto.ProductSingleDTO;
 
 import java.io.IOException;
 import java.util.List;
 
 public interface IProductGateway {
-    List<ProductDTO> getAllProducts() throws IOException;
+    List<ProductListDTO> getAllProducts() throws IOException;
+    ProductSingleDTO getProductById(int id) throws IOException;
 }

--- a/src/main/java/org/example/ecommercespring/gateway/IProductGateway.java
+++ b/src/main/java/org/example/ecommercespring/gateway/IProductGateway.java
@@ -1,0 +1,10 @@
+package org.example.ecommercespring.gateway;
+
+import org.example.ecommercespring.dto.ProductDTO;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface IProductGateway {
+    List<ProductDTO> getAllProducts() throws IOException;
+}

--- a/src/main/java/org/example/ecommercespring/gateway/api/FakeStoreProductApi.java
+++ b/src/main/java/org/example/ecommercespring/gateway/api/FakeStoreProductApi.java
@@ -1,10 +1,15 @@
 package org.example.ecommercespring.gateway.api;
 
 import org.example.ecommercespring.dto.FakeStoreProductResponseDTO;
+import org.example.ecommercespring.dto.FakeStoreSingleProductResponseDTO;
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 
 public interface FakeStoreProductApi {
     @GET("products")
     Call<FakeStoreProductResponseDTO> getAllProducts();
+
+    @GET("products/{id}")
+    Call<FakeStoreSingleProductResponseDTO> getProductById(@Path("id") int id);
 }

--- a/src/main/java/org/example/ecommercespring/gateway/api/FakeStoreProductApi.java
+++ b/src/main/java/org/example/ecommercespring/gateway/api/FakeStoreProductApi.java
@@ -1,0 +1,10 @@
+package org.example.ecommercespring.gateway.api;
+
+import org.example.ecommercespring.dto.FakeStoreProductResponseDTO;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface FakeStoreProductApi {
+    @GET("products")
+    Call<FakeStoreProductResponseDTO> getAllProducts();
+}

--- a/src/main/java/org/example/ecommercespring/services/FakeStoreProductService.java
+++ b/src/main/java/org/example/ecommercespring/services/FakeStoreProductService.java
@@ -1,6 +1,7 @@
 package org.example.ecommercespring.services;
 
-import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.dto.ProductListDTO;
+import org.example.ecommercespring.dto.ProductSingleDTO;
 import org.example.ecommercespring.gateway.IProductGateway;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +18,12 @@ public class FakeStoreProductService implements IProductService {
     }
 
     @Override
-    public List<ProductDTO> getAllProducts() throws IOException {
+    public List<ProductListDTO> getAllProducts() throws IOException {
         return this.productGateway.getAllProducts();
+    }
+
+    @Override
+    public ProductSingleDTO getProductById(int id) throws IOException {
+        return this.productGateway.getProductById(id);
     }
 }

--- a/src/main/java/org/example/ecommercespring/services/FakeStoreProductService.java
+++ b/src/main/java/org/example/ecommercespring/services/FakeStoreProductService.java
@@ -1,0 +1,23 @@
+package org.example.ecommercespring.services;
+
+import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.gateway.IProductGateway;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+public class FakeStoreProductService implements IProductService {
+
+    private final IProductGateway productGateway;
+
+    public FakeStoreProductService(IProductGateway productGateway) {
+        this.productGateway = productGateway;
+    }
+
+    @Override
+    public List<ProductDTO> getAllProducts() throws IOException {
+        return this.productGateway.getAllProducts();
+    }
+}

--- a/src/main/java/org/example/ecommercespring/services/IProductService.java
+++ b/src/main/java/org/example/ecommercespring/services/IProductService.java
@@ -1,10 +1,12 @@
 package org.example.ecommercespring.services;
 
-import org.example.ecommercespring.dto.ProductDTO;
+import org.example.ecommercespring.dto.ProductListDTO;
+import org.example.ecommercespring.dto.ProductSingleDTO;
 
 import java.io.IOException;
 import java.util.List;
 
 public interface IProductService {
-    List<ProductDTO> getAllProducts() throws IOException;
+    List<ProductListDTO> getAllProducts() throws IOException;
+    ProductSingleDTO getProductById(int id) throws IOException;
 }

--- a/src/main/java/org/example/ecommercespring/services/IProductService.java
+++ b/src/main/java/org/example/ecommercespring/services/IProductService.java
@@ -1,0 +1,10 @@
+package org.example.ecommercespring.services;
+
+import org.example.ecommercespring.dto.ProductDTO;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface IProductService {
+    List<ProductDTO> getAllProducts() throws IOException;
+}


### PR DESCRIPTION
### 📝 Description

This PR introduces the integration of **Get All Products** and **Get Product By ID** APIs using **Retrofit** in a clean layered architecture, with the following updates:

- ✅ Created **separate DTOs** (`ProductListDTO`, `ProductSingleDTO`) for clear distinction between list and detailed product views.
- 🧱 Implemented `IProductService`, `FakeStoreProductService` for business logic delegation.
- 🌐 Integrated `IProductGateway` and `FakeStoreProductGateway` for external API handling via Retrofit.
- 🔧 Defined `FakeStoreProductApi` interface to map endpoints from FakeStore.
- 🚦 Hooked everything up in `ProductController` with endpoints:
  - `GET /api/products`
  - `GET /api/products/{id}`

### 📦 Affected Modules
- `dto/`
- `services/`
- `gateway/`
- `controllers/`

### ✅ Checklist
- [x] Retrofit API integration
- [x] DTO separation for list and single product
- [x] Clean architecture followed (Controller → Service → Gateway → API)
- [x] Exception handling for null or failed API responses

### 📌 Notes
- This is part of ongoing work to modularize product handling logic and prepare for additional API features like product creation and deletion.

![image](https://github.com/user-attachments/assets/08455a2e-8af3-4484-a57c-971476461f99)
![image](https://github.com/user-attachments/assets/7bc2f08f-80e2-4e7c-827d-fdac3b9a813e)
