### PR TITLE
feat: add alternate OkHttp-based gateway implementation for category API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'io.github.cdimascio:dotenv-java:3.2.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/ecommercespring/configuration/OkHttpConfig.java
+++ b/src/main/java/org/example/ecommercespring/configuration/OkHttpConfig.java
@@ -1,0 +1,22 @@
+package org.example.ecommercespring.configuration;
+
+import okhttp3.OkHttpClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@ConditionalOnProperty(name = "http.client", havingValue = "okhttp")
+public class OkHttpConfig {
+
+    @Bean
+    public OkHttpClient okHttpClient() {
+        return new OkHttpClient.Builder()
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(15, TimeUnit.SECONDS)
+                .writeTimeout(15, TimeUnit.SECONDS)
+                .build();
+    }
+}

--- a/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
+++ b/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
@@ -1,14 +1,15 @@
 package org.example.ecommercespring.configuration;
 
 import org.example.ecommercespring.gateway.api.FakeStoreCategoryApi;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 @Configuration
+@ConditionalOnProperty(name = "http.client", havingValue = "retrofit", matchIfMissing = true)
 public class RetrofitConfig {
-
 
     @Bean
     public Retrofit retrofit() {
@@ -22,5 +23,4 @@ public class RetrofitConfig {
     public FakeStoreCategoryApi fakeStoreCategoryApi(Retrofit retrofit) {
         return retrofit.create(FakeStoreCategoryApi.class);
     }
-
 }

--- a/src/main/java/org/example/ecommercespring/gateway/FakeStoreCategoryGateway.java
+++ b/src/main/java/org/example/ecommercespring/gateway/FakeStoreCategoryGateway.java
@@ -1,37 +1,97 @@
 package org.example.ecommercespring.gateway;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.example.ecommercespring.dto.CategoryDTO;
 import org.example.ecommercespring.dto.FakeStoreCategoryResponseDTO;
 import org.example.ecommercespring.gateway.api.FakeStoreCategoryApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 @Component
-public class FakeStoreCategoryGateway implements ICategoryGateway{
+@Primary
+public class FakeStoreCategoryGateway implements ICategoryGateway {
 
-    private final FakeStoreCategoryApi fakeStoreCategoryApi;
+    private final HttpClientDelegate delegate;
 
-    public FakeStoreCategoryGateway(FakeStoreCategoryApi fakeStoreCategoryApi) {
-        this.fakeStoreCategoryApi = fakeStoreCategoryApi;
+    public FakeStoreCategoryGateway(
+            @Autowired(required = false) OkHttpClient okHttpClient,
+            @Autowired(required = false) FakeStoreCategoryApi retrofitApi,
+            ObjectMapper objectMapper) {
+
+        if (okHttpClient != null) {
+            this.delegate = new OkHttpDelegate(okHttpClient, objectMapper);
+        } else if (retrofitApi != null) {
+            this.delegate = new RetrofitDelegate(retrofitApi);
+        } else {
+            throw new IllegalStateException("No HTTP client implementation available");
+        }
+    }
+    private interface HttpClientDelegate {
+        List<CategoryDTO> getAllCategories() throws IOException;
+    }
+
+    private static class OkHttpDelegate implements HttpClientDelegate {
+        private final OkHttpClient client;
+        private final ObjectMapper mapper;
+        private static final String BASE_URL = "https://fakestoreapi.in/api/";
+
+        OkHttpDelegate(OkHttpClient client, ObjectMapper mapper) {
+            this.client = client;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public List<CategoryDTO> getAllCategories() throws IOException {
+            Request request = new Request.Builder()
+                    .url(BASE_URL + "products/category")
+                    .build();
+
+            try (Response response = client.newCall(request).execute()) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    throw new IOException("HTTP request failed: " + response);
+                }
+
+                String responseBody = Objects.requireNonNull(response.body()).string();
+                FakeStoreCategoryResponseDTO apiResponse = mapper.readValue(
+                        responseBody,
+                        FakeStoreCategoryResponseDTO.class);
+
+                return apiResponse.getCategories().stream()
+                        .map(CategoryDTO::new)
+                        .toList();
+            }
+        }
+    }
+
+    private static class RetrofitDelegate implements HttpClientDelegate {
+        private final FakeStoreCategoryApi api;
+
+        RetrofitDelegate(FakeStoreCategoryApi api) {
+            this.api = api;
+        }
+
+        @Override
+        public List<CategoryDTO> getAllCategories() throws IOException {
+            return api.getAllFakeCategories()
+                    .execute()
+                    .body()
+                    .getCategories()
+                    .stream()
+                    .map(CategoryDTO::new)
+                    .toList();
+        }
     }
 
     @Override
     public List<CategoryDTO> getAllCategories() throws IOException {
-        // 1. Make the HTTP request to the FakeStore API to fetch all categories
-        FakeStoreCategoryResponseDTO response = this.fakeStoreCategoryApi.getAllFakeCategories().execute().body();
-
-        // 2. Check if the response is null and throw an IOException if it is
-        if(response == null) {
-            throw new IOException("Failed to fetch categories from FakeStore API");
-        }
-
-        // 3. Map the response to a list of CategoryDTO objects
-        return response.getCategories().stream()
-                .map(category -> CategoryDTO.builder()
-                        .name(category)
-                        .build())
-                .toList();
+        return delegate.getAllCategories();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,9 @@
 spring.application.name=EcommerceSpring
 
 server.port=${PORT}
+
+# Choose between 'okhttp' or 'retrofit'
+http.client=${CLIENT}
+
+# API Configuration
+api.base.url=${BASEURL}


### PR DESCRIPTION

# Description

This PR adds a new `OkHttpCategoryGateway` as an alternative HTTP client to okHttp for fetching data. The gateway implementation is selected dynamically using a `.env` config (`CLIENT=okhttp` or `CLIENT=retrofit`).

---

## Changes Made

- ✅ Added `OkHttpCategoryGateway.java`
- ✅ Added `OkHttpConfig.java` for `OkHttpClient` bean
- 🆕 Introduced `.env` support for client selection

---

## .env Config Required

Create a `.env` file with:

```env
PORT=3001
CLIENT=okhttp
BASEURL=https://fakestoreapi.in/api
```

![image](https://github.com/user-attachments/assets/69df13f0-05ed-4da1-aff9-09565e38ef94)
