### PR TITLE
Update the code to store fakeStore baseUrl in dotenv file

### DIFF
--- a/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
+++ b/src/main/java/org/example/ecommercespring/configuration/RetrofitConfig.java
@@ -2,6 +2,7 @@ package org.example.ecommercespring.configuration;
 
 import org.example.ecommercespring.gateway.api.FakeStoreCategoryApi;
 import org.example.ecommercespring.gateway.api.FakeStoreProductApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit2.Retrofit;
@@ -9,12 +10,14 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 @Configuration
 public class RetrofitConfig {
+    @Value("${fakestore.base.url}")
+    private String baseApiUrl;
 
 
     @Bean
     public Retrofit retrofit() {
         return new Retrofit.Builder()
-                .baseUrl("https://fakestoreapi.in/api/")
+                .baseUrl(baseApiUrl)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=EcommerceSpring
 
 server.port=${PORT}
+fakestore.base.url=${FAKESTORE-BASEURL}


### PR DESCRIPTION
This PR updates the code to move the hardcoded FakeStore API base URL into environment configuration. This makes the application more flexible, maintainable, and suitable for different environments (e.g., dev, staging, prod).

Changes Made:
Added FAKESTORE_BASE_URL to .env or equivalent environment config file.
Updated Retrofit initialization to read the base URL from the environment variable.
Refactored existing code to remove the hardcoded base URL.

Benefits:
Easier to switch API endpoints without modifying code.
Better practice for managing API configs.
Prepares the app for multi-environment support.